### PR TITLE
chore: update GitHub Actions versions

### DIFF
--- a/.github/workflows/documentbot.yml
+++ b/.github/workflows/documentbot.yml
@@ -42,7 +42,7 @@ jobs:
       pull-requests: write 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - uses: streamnative/github-workflow-libraries/doc-label-check@master
         with:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Setup JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: 17

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -16,9 +16,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Setup JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: 17


### PR DESCRIPTION
Updates GitHub Actions versions found by the workflow audit.

## Changes

### `.github/workflows/integration-tests.yml`

| Action | Current | Required | Line |
|---|---:|---:|---:|
| `actions/checkout` | `v3` | `v6` | 18 |
| `actions/setup-java` | `v3` | `v5` | 20 |

### `.github/workflows/documentbot.yml`

| Action | Current | Required | Line |
|---|---:|---:|---:|
| `actions/checkout` | `v2` | `v6` | 45 |

### `.github/workflows/unit-tests.yml`

| Action | Current | Required | Line |
|---|---:|---:|---:|
| `actions/checkout` | `v3` | `v6` | 19 |
| `actions/setup-java` | `v3` | `v5` | 21 |

---

Generated by the GitHub Actions workflow audit tool.
